### PR TITLE
Remove install - deprecated and remove open-vm-tools 

### DIFF
--- a/.ansible-ci/files/templated_contexts/rocky8-minimal/rocky8-minimal.ks
+++ b/.ansible-ci/files/templated_contexts/rocky8-minimal/rocky8-minimal.ks
@@ -10,7 +10,6 @@
 # https://catalog.redhat.com/software/containers/detail/5c359a62bed8bd75a2c3fba8
 
 # Basic setup information
-install
 url --url https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/
 bootloader --disabled
 timezone --isUtc --nontp Etc/UTC
@@ -39,6 +38,7 @@ rootfiles
 -gnupg2-smime
 -kernel
 -libss
+-open-vm-tools
 -pinentry
 -qemu-guest-agent
 -shared-mime-info


### PR DESCRIPTION
To get the root fs to build I had to remove open vm tools which depends on fuse-libs. I also removed install since it is deprecated. After making these changes I could get a successful build of the root fs to create container from scratch.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**
N/A


**What is the new behavior (if this is a feature change)?**
The container can build a root filesystem without erroring that open-vm-tools cannot be installed due to dependency of fuse-libs.


**Other information**:
